### PR TITLE
ci: add monorepo SDK test trigger on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,19 @@ jobs:
 
       - name: Run tests
         run: ./scripts/test
+
+  trigger-monorepo-tests:
+    timeout-minutes: 5
+    name: trigger monorepo tests
+    runs-on: ubuntu-latest
+    needs: build
+    # Only run for PRs in the public repo, after the tarball is uploaded
+    if: github.repository == 'flowglad/flowglad-node' && github.event_name == 'pull_request'
+    steps:
+      - name: Trigger flowglad monorepo SDK tests
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.MONOREPO_DISPATCH_TOKEN }}
+          repository: flowglad/flowglad
+          event-type: test-stainless-sdk
+          client-payload: '{"commit_hash": "${{ github.event.pull_request.head.sha }}"}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,9 @@ jobs:
     timeout-minutes: 5
     name: trigger monorepo tests
     runs-on: ubuntu-latest
-    needs: build
-    # Only run for PRs in the public repo, after the tarball is uploaded
+    # Only run for PRs in the public repo
+    # Note: No 'needs: build' because the tarball is uploaded by Stainless's internal CI
+    # (stainless-sdks/flowglad-typescript), not by this repo's build job
     if: github.repository == 'flowglad/flowglad-node' && github.event_name == 'pull_request'
     steps:
       - name: Trigger flowglad monorepo SDK tests


### PR DESCRIPTION
Add a new GitHub Actions job that automatically triggers the monorepo test suite whenever a PR is opened in flowglad-node. This validates that Stainless-generated SDK versions don't break the monorepo before publishing to npm.

The job dispatches to flowglad/flowglad with the PR commit hash, which the test-stainless-sdk workflow uses to fetch the corresponding SDK tarball from Stainless and run the full test suite.

This requires setting up a `MONOREPO_DISPATCH_TOKEN` secret (a GitHub PAT with `repo` scope) in the flowglad-node repository secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI job that triggers an external test workflow for pull requests.
  * Job configured with a short timeout and runs on a standard Linux runner.
  * Runs conditionally for pull requests and is independent of existing job dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->